### PR TITLE
Change the commit hook name

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "npm": ">= 2.0.0"
   },
   "scripts": {
-    "postinstall": "cp node_modules/angular-precommit/index.js .git/hooks/commit-msg",
+    "install:commit-hook": "cp node_modules/angular-precommit/index.js .git/hooks/commit-msg",
     "release:patch": "githubrelease -tb patch",
     "release:minor": "githubrelease -tb minor",
     "release:major": "githubrelease -tb major",


### PR DESCRIPTION
Change the name so that npm install does not attempt to use the postinstall hook.
